### PR TITLE
git-ignore more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/build/
 /node_modules/
+/package-lock.json
 /target/


### PR DESCRIPTION
I'm getting these files (`build/`, `package-lock.json`) after running `npm install` using tree-sitter 0.19.5 so I added them to the .gitignore.

PS: thanks for this great project! I'm looking into using it for SQL syntax support in [Semgrep](https://github.com/returntocorp/semgrep).
