### PR TITLE
update tree-sitter to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19.3"
+tree-sitter = "0.20.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -35,7 +35,7 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "prettier": "2.3.0",
-        "tree-sitter-cli": "0.19.5"
+        "tree-sitter-cli": "0.20.0"
     },
     "tree-sitter": [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,14 +3,14 @@ lockfileVersion: 5.3
 specifiers:
   nan: 2.14.2
   prettier: 2.3.0
-  tree-sitter-cli: 0.19.5
+  tree-sitter-cli: 0.20.0
 
 dependencies:
   nan: 2.14.2
 
 devDependencies:
   prettier: 2.3.0
-  tree-sitter-cli: 0.19.5
+  tree-sitter-cli: 0.20.0
 
 packages:
 
@@ -24,8 +24,8 @@ packages:
     hasBin: true
     dev: true
 
-  /tree-sitter-cli/0.19.5:
-    resolution: {integrity: sha512-kRzKrUAwpDN9AjA3b0tPBwT1hd8N2oQvvvHup2OEsX6mdsSMLmAvR+NSqK9fe05JrRbVvG8mbteNUQsxlMQohQ==}
+  /tree-sitter-cli/0.20.0:
+    resolution: {integrity: sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg==}
     hasBin: true
     requiresBuild: true
     dev: true


### PR DESCRIPTION
hi! thanks for publishing this grammar. this PR just bumps the tree-sitter versions to latest. doesn't seem to introduce any issues as far as i can tell, though i am only using it in a pretty simple app. :v: