### PR TITLE
Fixes tree-sitter-sqlite/issues/5

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -222,7 +222,7 @@ module.exports = grammar({
 
 		string_literal: ($) => $._string,
 
-		blob_literal: ($) => seq(choice("x", "X"), $._string),
+		blob_literal: ($) => seq(choice("x'", "X'"), /(''|[^'])*/, "'"),
 
 		identifier: ($) =>
 			choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -898,17 +898,21 @@
           "members": [
             {
               "type": "STRING",
-              "value": "x"
+              "value": "x'"
             },
             {
               "type": "STRING",
-              "value": "X"
+              "value": "X'"
             }
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_string"
+          "type": "PATTERN",
+          "value": "(''|[^'])*"
+        },
+        {
+          "type": "STRING",
+          "value": "'"
         }
       ]
     },
@@ -3456,15 +3460,15 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "blob_literal"
+        },
+        {
+          "type": "SYMBOL",
           "name": "numeric_literal"
         },
         {
           "type": "SYMBOL",
           "name": "string_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "blob_literal"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6481,7 +6481,7 @@
     "named": true
   },
   {
-    "type": "X",
+    "type": "X'",
     "named": false
   },
   {
@@ -6501,7 +6501,7 @@
     "named": true
   },
   {
-    "type": "x",
+    "type": "x'",
     "named": false
   },
   {


### PR DESCRIPTION
Fixes #5 (by some definition of fixes).  I've added a tighter binding of the blob prefix 'x' with the opening apostrophe of a string literal.  Instead of reusing the _string rule, it is now embedded in the blob_literal rule.

The parser.c, grammar.json, and node-type.json were updated as per `make gen` and `make test`.